### PR TITLE
Parameterize source repository

### DIFF
--- a/.github/workflows/AutoTagging.yml
+++ b/.github/workflows/AutoTagging.yml
@@ -12,7 +12,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Tagging
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Deploy2OM.yml
+++ b/.github/workflows/Deploy2OM.yml
@@ -2,23 +2,19 @@ name: Deploy2OM
 
 on:
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
-  push:
-    branches: [ main ]
-    branches-ignore:
-    tags:
-    tags-ignore:
-    paths:
-      - 'README.md'   # limit trigger to the target-filepath
+#  push:
+#    branches: [main]
+#    paths:
+#      - "README.md" # limit trigger to the target-path
 
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: sator-imaging/Copy-to-Another-Repository@main   # @v1 or @main
+      - uses: sator-imaging/Copy-to-Another-Repository@main # @v1 or @main
         with:
-
           # required parameters
-          target-filepath: 'README.md'     # file path to copy
-          output-branch: 'master'  # branch name to create pull request
-          output-repo: 'SatorImaging/OpenManual'
+          target-path: "README.md" # file path to copy
+          output-branch: "master" # branch name to create pull request
+          output-repo: "SatorImaging/OpenManual"
           git-token: ${{ secrets.Deploy2OM }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'README.md'  # limit trigger to the target-filepath.
+      - 'README.md'  # limit trigger to the target-path.
                      # It's not elegant to set same value in two options but
                      # there is no way to retrieve this value in composite action.
 
@@ -27,14 +27,14 @@ jobs:
         with:
 
           # required parameters
-          target-filepath: 'README.md'      # file path(s) to copy
-          output-branch: 'main or master'   # branch name to create pull request
-          output-repo: 'Owner/AnotherRepository' # name of org/repo to copy file(s) and open PR
-          git-token: ${{ secrets.TOKEN_TO_ACCESS_OUTPUT_REPO }}
+          target-path: 'README.md'   # file/folder path(s) to copy
+          output-branch: "main"   # base branch name to file pull request against
+          output-repo: 'Owner/AnotherRepository'   # name of org/repo to copy file(s) and open PR
+          git-token: ${{ secrets.TOKEN_TO_ACCESS_OUTPUT_REPO }}   # name of GitHub token
           
           # optional parameters and default values
-          target-repo: 'AnotherOwner/AnotherRepository' # name of remote org/repo to copy file(s) from
-          commit-message-prefix: '[actions] '   # followed by source repository and file name
+          target-repo: "AnotherOwner/AnotherRepository"   # name of remote org/repo to copy file(s) from
+          commit-message-prefix: "[actions] "   # followed by source repository and file name
           output-directory: "${{ github.event.repository.name }}"   # copy file into sub directory
           pr-branch-prefix: "actions/${{ github.event.repository.name }}"   # branch name prefix followed by date and time
           pr-title: "GitHub Actions: ${{ github.event.repository.name }}"   # followed by source repository and file name

--- a/README.md
+++ b/README.md
@@ -2,13 +2,10 @@
 
 `Copy-to-Another-Repository` is reusable workflow to copy selected file to another repository and create Pull Request (PR) to merge.
 
-
-
 ## Usage
 
 Create GitHub Actions like as follows.
 See [action.yml](https://github.com/sator-imaging/Copy-to-Another-Repository/blob/main/action.yml) for further details.
-
 
 ```yaml   {% raw %}
 name: GitHub-Actions-Name
@@ -17,9 +14,6 @@ on:
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
   push:
     branches: [ main ]
-    branches-ignore:
-    tags:
-    tags-ignore:
     paths:
       - 'README.md'  # limit trigger to the target-filepath.
                      # It's not elegant to set same value in two options but
@@ -33,12 +27,13 @@ jobs:
         with:
 
           # required parameters
-          target-filepath: 'README.md'      # file path to copy
+          target-filepath: 'README.md'      # file path(s) to copy
           output-branch: 'main or master'   # branch name to create pull request
-          output-repo: 'Owner/AnotherRepository'
+          output-repo: 'Owner/AnotherRepository' # name of org/repo to copy file(s) and open PR
           git-token: ${{ secrets.TOKEN_TO_ACCESS_OUTPUT_REPO }}
           
           # optional parameters and default values
+          target-repo: 'AnotherOwner/AnotherRepository' # name of remote org/repo to copy file(s) from
           commit-message-prefix: '[actions] '   # followed by source repository and file name
           output-directory: "${{ github.event.repository.name }}"   # copy file into sub directory
           pr-branch-prefix: "actions/${{ github.event.repository.name }}"   # branch name prefix followed by date and time
@@ -50,8 +45,6 @@ jobs:
 # {% endraw %}
 ```
 
-
-
 ## Learning Resources
 
 - [Metadata syntax for GitHub Actions](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions)
@@ -61,8 +54,6 @@ jobs:
   - [Default environment variables](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables)
 - [Webhook events and payloads](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads)
 - [Workflow commands for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions)
-
-
 
 ## Copyright
 

--- a/action.yml
+++ b/action.yml
@@ -63,27 +63,21 @@ runs:
         echo "ACTION_REPO=$( echo $GITHUB_ACTION | sed 's/_/\//g' | sed 's/\///' )" >> $GITHUB_ENV
         echo "PR_BRANCH=${{ inputs.pr-branch-prefix }}---$(date +'%Y-%m-%d--%H-%M-%S')" >> $GITHUB_ENV
         echo "PR_MESSAGE=${{ inputs.pr-message }}" >> $GITHUB_ENV
-        # echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
         echo "PR_TITLE_APPENDIX= ${{ inputs.target-repo }}" >> $GITHUB_ENV
         echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-repo }}" >> $GITHUB_ENV
         echo "target repo processed as: ${{ inputs.target-repo}}"
       shell: bash
 
-    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       with:
-        persist-credentials: false
-        # TODO: is this temp dir actually needed?
-        # path: "${{ env.TMP_DSTDIR }}"
         repository: "${{ inputs.output-repo }}"
+        persist-credentials: false
     
-    # - working-directory: "${{ env.TMP_DSTDIR }}"
     - run: |
         git config --global user.name "${{ inputs.git-name }}"
         git config --global user.email "${{ inputs.git-email }}"
         git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
         mkdir -p "${{ inputs.output-directory }}"
-        # TODO: See if this still works after swapping checkout step
-        # git checkout -b "${{ env.PR_BRANCH }}"
         git remote add -f ${{ inputs.output-directory }}/${{ inputs.target-repo }} https://github.com/${{ inputs.target-repo }}
         git merge -s ours --no-commit --allow-unrelated-histories ${{ inputs.output-directory }}/${{ inputs.target-repo}}/${{ inputs.output-branch }}
         git read-tree --prefix=${{ inputs.output-directory }}/${{ inputs.target-repo}} -u ${{ inputs.output-directory }}/${{ inputs.target-repo}}/${{ inputs.output-branch }}

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,7 @@ runs:
         cd "${{ env.TMP_DSTDIR }}"
         pwd
         ls -l ./*
-        ls -l ../TMP_SRCDIR/*
+        ls -l ../${{ env.TMP_SRCDIR }}/*
       shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"

--- a/action.yml
+++ b/action.yml
@@ -97,20 +97,22 @@ runs:
       run: |
         git checkout -b "${{ env.PR_BRANCH }}"
         shopt -s dotglob
-        shopt -s extglob
-        mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} !(.git) ${{ inputs.output-directory }}/
+        mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         ls -la ${{ inputs.output-directory }}/*
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
-        # ls -la ${{ inputs.output-directory }}/
+        git subtree add --prefix ${{ inputs.output-directory }} https://github.com/${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
         # git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
         # git add "${{ inputs.output-directory }}/."
-        # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
-        # git push origin HEAD
+        git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
+        git push origin HEAD
+        curl -X POST -H "Accept:application/vnd.github.v3+json" \
+          "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" \
+          -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
       shell: bash
   
     # - working-directory: "${{ env.TMP_DSTDIR }}"
     #   run: |
-    #     curl -X POST -H "Accept:application/vnd.github.v3+json" \
-    #       "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" \
-    #       -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
+        # curl -X POST -H "Accept:application/vnd.github.v3+json" \
+        #   "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" \
+        #   -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
     #   shell: bash

--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
         # ls -la ${{ inputs.output-directory }}/*
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         git subtree add --prefix ${{ inputs.output-directory }} https://github.com/${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
-        git subtree push --prefix=${{ inputs.output-directory }} ${{ inputs.output-branch }} ${{ inputs.output-branch }} 
+        git subtree push --prefix=${{ inputs.output-directory }} https://github.com/${{ inputs.target-repo }} "${{ env.PR_BRANCH }}"
         # git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"

--- a/action.yml
+++ b/action.yml
@@ -101,7 +101,7 @@ runs:
       run: |
         git checkout -b "${{ env.PR_BRANCH }}"
         mkdir -p "${{ inputs.output-directory }}"
-        mv -vf ".././${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
+        mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
         git add "${{ inputs.output-directory }}/."
         git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -70,9 +70,11 @@ runs:
       shell: bash
     - run: echo "PR_MESSAGE=${{ inputs.pr-message }}" >> $GITHUB_ENV
       shell: bash
-    - run: echo "TMP_SRCDIR=./source" >> $GITHUB_ENV
+    - run: echo "TMP_SRCDIR=source" >> $GITHUB_ENV
+    # - run: echo "TMP_SRCDIR=./source" >> $GITHUB_ENV
       shell: bash
-    - run: echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
+    - run: echo "TMP_DSTDIR=dest" >> $GITHUB_ENV
+    # - run: echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
       shell: bash
     - run: echo "PR_TITLE_APPENDIX= - ${{ inputs.target-path }}" >> $GITHUB_ENV
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -104,6 +104,7 @@ runs:
         # ls -la ${{ inputs.output-directory }}/*
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         git subtree add --prefix ${{ inputs.output-directory }} https://github.com/${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
+        git remote add ${{ inputs.target-repo }} https://github.com/${{ inputs.target-repo }}
         git subtree push --prefix=${{ inputs.output-directory }} https://github.com/${{ inputs.target-repo }} "${{ env.PR_BRANCH }}"
         # git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
         # git add "${{ inputs.output-directory }}/."

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,6 @@ inputs:
     required: false
     description: "Name of remote repository to copy file(s) from."
     default: "cisco-ospo/sample-project"
-  target-path:
-    required: true
-    description: "File/folder path(s) to copy to the output repository."
-    default: "*"
   output-repo:
     required: true
     description: "Name of the org/repo where the pull request will be filed."
@@ -67,17 +63,17 @@ runs:
         echo "ACTION_REPO=$( echo $GITHUB_ACTION | sed 's/_/\//g' | sed 's/\///' )" >> $GITHUB_ENV
         echo "PR_BRANCH=${{ inputs.pr-branch-prefix }}---$(date +'%Y-%m-%d--%H-%M-%S')" >> $GITHUB_ENV
         echo "PR_MESSAGE=${{ inputs.pr-message }}" >> $GITHUB_ENV
-        echo "TMP_SRCDIR=./source" >> $GITHUB_ENV
+        # echo "TMP_SRCDIR=./source" >> $GITHUB_ENV
         echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
         echo "PR_TITLE_APPENDIX= ${{ inputs.target-repo }}" >> $GITHUB_ENV
         echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-repo }}" >> $GITHUB_ENV
       shell: bash
 
-    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      with:
-        persist-credentials: false
-        path: "${{ env.TMP_SRCDIR }}"
-        repository: "${{ inputs.target-repo }}"
+    # - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+    #   with:
+    #     persist-credentials: false
+    #     path: "${{ env.TMP_SRCDIR }}"
+    #     repository: "${{ inputs.target-repo }}"
 
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       with:
@@ -85,41 +81,32 @@ runs:
         path: "${{ env.TMP_DSTDIR }}"
         repository: "${{ inputs.output-repo }}"
 
-    # - working-directory: "${{ env.TMP_DSTDIR }}"
-    #   run: |
-    #    git config --global user.name "${{ inputs.git-name }}"
-    #    git config --global user.email "${{ inputs.git-email }}"
-    #    git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
-    #    mkdir -p "${{ inputs.output-directory }}"
-    #   shell: bash
+    - working-directory: "${{ env.TMP_DSTDIR }}"
+      run: |
+       git config --global user.name "${{ inputs.git-name }}"
+       git config --global user.email "${{ inputs.git-email }}"
+       git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
+       mkdir -p "${{ inputs.output-directory }}"
+      shell: bash
     
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |
-        git config --global user.name "${{ inputs.git-name }}"
-        git config --global user.email "${{ inputs.git-email }}"
-        git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
-        # git checkout -b "${{ env.PR_BRANCH }}"
-        # shopt -s dotglob
-        # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
-        # ls -la ${{ inputs.output-directory }}/*
-        # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         git checkout -b "${{ env.PR_BRANCH }}"
-        git remote add ${{ inputs.target-repo }} https://github.com/${{ inputs.target-repo }}
-        git subtree add --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
-        git subtree pull --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
-        git subtree push --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} "${{ env.PR_BRANCH }}"
-        # git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
-        # git add "${{ inputs.output-directory }}/."
-        # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
-        # git push origin HEAD
+        # git remote add -f osc/cisco-ospo/sample-project https://github.com/cisco-ospo/sample-project
+        git remote add -f ${{ inputs.output-directory }}/${{ inputs.target-repo }} https://github.com/${{ inputs.target-repo }}
+        # git merge -s ours --no-commit --allow-unrelated-histories osc/cisco-ospo/sample-project/main
+        git merge -s ours --no-commit --allow-unrelated-histories ${{ inputs.output-directory }}/${{ inputs.target-repo}}/${{ inputs.output-branch }}
+        # git read-tree --prefix=osc/cisco-ospo/sample-project -u osc/cisco-ospo/sample-project/main
+        git read-tree --prefix=${{ inputs.output-directory }}/${{ inputs.target-repo}} -u ${{ inputs.output-directory }}/${{ inputs.target-repo}}/${{ inputs.output-branch }}
+        # git commit -m "Subtree merged in cisco-ospo/sample-project"
+        git commit -m "Subtree merged in ${{ inputs.target-repo }}"
+        # git push origin outbound-review_cisco-ospo-sample-project_1
+        git push origin "${{ env.PR_BRANCH }}"
+      shell: bash
+  
+    - working-directory: "${{ env.TMP_DSTDIR }}"
+      run: |
         curl -X POST -H "Accept:application/vnd.github.v3+json" \
           "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" \
           -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
       shell: bash
-  
-    # - working-directory: "${{ env.TMP_DSTDIR }}"
-    #   run: |
-        # curl -X POST -H "Accept:application/vnd.github.v3+json" \
-        #   "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" \
-        #   -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
-    #   shell: bash

--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
         # ls -la ${{ inputs.output-directory }}/*
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         git checkout -b "${{ env.PR_BRANCH }}"
-        git remote add ${{ inputs.target-repo }} git@github.com:${{ inputs.target-repo }}.git
+        git remote add ${{ inputs.target-repo }} https://github.com/${{ inputs.target-repo }}
         git subtree add --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
         git subtree pull --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
         git subtree push --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} "${{ env.PR_BRANCH }}"

--- a/action.yml
+++ b/action.yml
@@ -102,10 +102,12 @@ runs:
       # mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
       run: |
         git checkout -b "${{ env.PR_BRANCH }}"
+        ls -l /home/runner/work/outbound-review/outbound-review/source/*
+        ls -l /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}
         mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}
-        git add "${{ inputs.output-directory }}/."
-        git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
-        git push origin HEAD
+        # git add "${{ inputs.output-directory }}/."
+        # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
+        # git push origin HEAD
       shell: bash
   
     #- run: curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"

--- a/action.yml
+++ b/action.yml
@@ -103,9 +103,10 @@ runs:
       run: |
         git checkout -b "${{ env.PR_BRANCH }}"
         pwd
-        ls -l /home/runner/work/outbound-review/outbound-review/source/*
-        mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/
-        ls -l /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/*
+        ls -l  "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}"
+        mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}/"
+        # mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/
+        ls -l "../${{ inputs.output-directory }}/"
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         # git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -69,12 +69,6 @@ runs:
         echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-repo }}" >> $GITHUB_ENV
       shell: bash
 
-    # - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-    #   with:
-    #     persist-credentials: false
-    #     path: "${{ env.TMP_SRCDIR }}"
-    #     repository: "${{ inputs.target-repo }}"
-
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       with:
         persist-credentials: false
@@ -92,15 +86,10 @@ runs:
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |
         git checkout -b "${{ env.PR_BRANCH }}"
-        # git remote add -f osc/cisco-ospo/sample-project https://github.com/cisco-ospo/sample-project
         git remote add -f ${{ inputs.output-directory }}/${{ inputs.target-repo }} https://github.com/${{ inputs.target-repo }}
-        # git merge -s ours --no-commit --allow-unrelated-histories osc/cisco-ospo/sample-project/main
         git merge -s ours --no-commit --allow-unrelated-histories ${{ inputs.output-directory }}/${{ inputs.target-repo}}/${{ inputs.output-branch }}
-        # git read-tree --prefix=osc/cisco-ospo/sample-project -u osc/cisco-ospo/sample-project/main
         git read-tree --prefix=${{ inputs.output-directory }}/${{ inputs.target-repo}} -u ${{ inputs.output-directory }}/${{ inputs.target-repo}}/${{ inputs.output-branch }}
-        # git commit -m "Subtree merged in cisco-ospo/sample-project"
         git commit -m "Subtree merged in ${{ inputs.target-repo }}"
-        # git push origin outbound-review_cisco-ospo-sample-project_1
         git push origin "${{ env.PR_BRANCH }}"
       shell: bash
   

--- a/action.yml
+++ b/action.yml
@@ -99,13 +99,13 @@ runs:
       shell: bash
     
     - working-directory: "${{ env.TMP_DSTDIR }}"
+      # mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
       run: |
-        # git checkout -b "${{ env.PR_BRANCH }}"
+        git checkout -b "${{ env.PR_BRANCH }}"
         mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}
-        # mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
-        # git add "${{ inputs.output-directory }}/."
-        # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
-        # git push origin HEAD
+        git add "${{ inputs.output-directory }}/."
+        git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
+        git push origin HEAD
       shell: bash
   
     #- run: curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   target-path:
     required: true
     description: "File/folder path(s) to copy to the output repository."
-    default: "./*"
+    default: "*"
   output-repo:
     required: true
     description: "Name of the org/repo where the pull request will be filed."
@@ -68,7 +68,7 @@ runs:
       shell: bash
     - run: echo "PR_BRANCH=${{ inputs.pr-branch-prefix }}---$(date +'%Y-%m-%d--%H-%M-%S')" >> $GITHUB_ENV
       shell: bash
-    - run: echo "PR_MESSAGE=${{ inputs.pr-message }}\\nAction:&nbsp;${{ github.server_url }}${{ env.ACTION_REPO }}" >> $GITHUB_ENV
+    - run: echo "PR_MESSAGE=${{ inputs.pr-message }}" >> $GITHUB_ENV
       shell: bash
     - run: echo "TMP_SRCDIR=./source" >> $GITHUB_ENV
       shell: bash
@@ -101,7 +101,7 @@ runs:
       # we cannot change current directory
     - run: cd "${{ env.TMP_DSTDIR }}"
       shell: bash
-    - run: ls .
+    - run: ls -l ./*
       shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"

--- a/action.yml
+++ b/action.yml
@@ -103,9 +103,11 @@ runs:
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         # ls -la ${{ inputs.output-directory }}/*
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
-        git subtree add --prefix ${{ inputs.output-directory }} https://github.com/${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
-        git remote add ${{ inputs.target-repo }} https://github.com/${{ inputs.target-repo }}
-        git subtree push --prefix=${{ inputs.output-directory }} https://github.com/${{ inputs.target-repo }} "${{ env.PR_BRANCH }}"
+        git checkout -b "${{ env.PR_BRANCH }}"
+        git remote add git@github.com:${{ inputs.target-repo }}.git
+        git subtree add --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
+        git subtree pull --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
+        git subtree push --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} "${{ env.PR_BRANCH }}"
         # git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"

--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,8 @@ runs:
         # git checkout -b "${{ env.PR_BRANCH }}"
         pwd
         ls -l ../
+        ls -l ../source/
+        ls -l ../source/*
         # ls -l  "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}"
         # mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}/"
         # mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/

--- a/action.yml
+++ b/action.yml
@@ -103,10 +103,11 @@ runs:
     - working-directory: "${{ env.TMP_DSTDIR }}"
       # mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
       run: |
-        git checkout -b "${{ env.PR_BRANCH }}"
+        # git checkout -b "${{ env.PR_BRANCH }}"
         pwd
-        ls -l  "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}"
-        mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}/"
+        ls -l ../
+        # ls -l  "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}"
+        # mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}/"
         # mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/
         ls -l "../${{ inputs.output-directory }}/"
         # git add "${{ inputs.output-directory }}/."

--- a/action.yml
+++ b/action.yml
@@ -101,6 +101,7 @@ runs:
       run: |
         git checkout -b "${{ env.PR_BRANCH }}"
         mkdir -p "${{ inputs.output-directory }}"
+        pwd
         mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
         git add "${{ inputs.output-directory }}/."
         git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"

--- a/action.yml
+++ b/action.yml
@@ -60,23 +60,17 @@ runs:
     - run: echo '::echo::on'
       shell: bash
 
-    # no way to retrieve added/modified files from github.event object.
     - run: cat "${{ github.event_path }}"
       shell: bash
 
-    - run: echo "ACTION_REPO=$( echo $GITHUB_ACTION | sed 's/_/\//g' | sed 's/\///' )" >> $GITHUB_ENV
-      shell: bash
-    - run: echo "PR_BRANCH=${{ inputs.pr-branch-prefix }}---$(date +'%Y-%m-%d--%H-%M-%S')" >> $GITHUB_ENV
-      shell: bash
-    - run: echo "PR_MESSAGE=${{ inputs.pr-message }}" >> $GITHUB_ENV
-      shell: bash
-    - run: echo "TMP_SRCDIR=./source" >> $GITHUB_ENV
-      shell: bash
-    - run: echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
-      shell: bash
-    - run: echo "PR_TITLE_APPENDIX= ${{ inputs.target-repo }}" >> $GITHUB_ENV
-      shell: bash
-    - run: echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-repo }}" >> $GITHUB_ENV
+    - run: |
+        echo "ACTION_REPO=$( echo $GITHUB_ACTION | sed 's/_/\//g' | sed 's/\///' )" >> $GITHUB_ENV
+        echo "PR_BRANCH=${{ inputs.pr-branch-prefix }}---$(date +'%Y-%m-%d--%H-%M-%S')" >> $GITHUB_ENV
+        echo "PR_MESSAGE=${{ inputs.pr-message }}" >> $GITHUB_ENV
+        echo "TMP_SRCDIR=./source" >> $GITHUB_ENV
+        echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
+        echo "PR_TITLE_APPENDIX= ${{ inputs.target-repo }}" >> $GITHUB_ENV
+        echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-repo }}" >> $GITHUB_ENV
       shell: bash
 
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -103,10 +97,12 @@ runs:
       run: |
         git checkout -b "${{ env.PR_BRANCH }}"
         shopt -s dotglob
-        mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
-        ls -la ${{ inputs.output-directory }}/
-        git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
-        # git add --all
+        mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} .
+        ls -la ./*
+        # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
+        # ls -la ${{ inputs.output-directory }}/
+        # git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
+        git add --all
         # git add --all "${{ inputs.output-directory }}/."
         git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -104,10 +104,11 @@ runs:
         # ls -la ${{ inputs.output-directory }}/*
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         git subtree add --prefix ${{ inputs.output-directory }} https://github.com/${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
+        git subtree push --prefix=${{ inputs.output-directory }} ${{ inputs.output-branch }} ${{ env.PR_BRANCH }}
         # git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
         # git add "${{ inputs.output-directory }}/."
-        git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
-        git push origin HEAD
+        # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
+        # git push origin HEAD
         curl -X POST -H "Accept:application/vnd.github.v3+json" \
           "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" \
           -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"

--- a/action.yml
+++ b/action.yml
@@ -96,9 +96,9 @@ runs:
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |
         git checkout -b "${{ env.PR_BRANCH }}"
-        shopt -s dotglob
-        mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
-        ls -la ${{ inputs.output-directory }}/*
+        # shopt -s dotglob
+        # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
+        # ls -la ${{ inputs.output-directory }}/*
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         git subtree add --prefix ${{ inputs.output-directory }} https://github.com/${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
         # git submodule add https://github.com/${{ inputs.target-repo }} outbound-review

--- a/action.yml
+++ b/action.yml
@@ -99,17 +99,24 @@ runs:
       shell: bash
 
       # we cannot change current directory
-    - run: cd "${{ env.TMP_DSTDIR }}"
-      shell: bash
-    - run: ls -l ./*
-      shell: bash
-
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: git checkout -b "${{ env.PR_BRANCH }}"
+    - run: |
+        cd "${{ env.TMP_DSTDIR }}"
+        pwd
+        ls -l ./*
+        ls -l ../TMP_SRCDIR/*
       shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: mkdir -p "${{ inputs.output-directory }}"
+      run: |
+        pwd
+        git checkout -b "${{ env.PR_BRANCH }}"
+      shell: bash
+
+    - working-directory: "${{ env.TMP_DSTDIR }}"
+      run: |
+        pwd
+        mkdir -p "${{ inputs.output-directory }}"
+        ls -l ./*
       shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"

--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
         # ls -la ${{ inputs.output-directory }}/*
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         git checkout -b "${{ env.PR_BRANCH }}"
-        git remote add git@github.com:${{ inputs.target-repo }}.git
+        git remote add ${{ inputs.target-repo }} git@github.com:${{ inputs.target-repo }}.git
         git subtree add --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
         git subtree pull --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
         git subtree push --prefix=${{ inputs.output-directory }} ${{ inputs.target-repo }} "${{ env.PR_BRANCH }}"

--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,8 @@ runs:
         shopt -s dotglob
         mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         ls -la ${{ inputs.output-directory }}/
-        git add "${{ inputs.output-directory }}/."
+        git add --all
+        # git add --all "${{ inputs.output-directory }}/."
         git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         git push origin HEAD
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   target-path:
     required: true
     description: "File/folder path(s) to copy to the output repository."
-    default: ""
+    default: "*"
   output-repo:
     required: true
     description: "Name of the org/repo where the pull request will be filed."
@@ -103,14 +103,14 @@ runs:
     
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |
-        # git checkout -b "${{ env.PR_BRANCH }}"
+        git checkout -b "${{ env.PR_BRANCH }}"
         shopt -s dotglob
-        mv -vf ../${{ env.TMP_SRCDIR }}/* ${{ inputs.output-directory }}/
+        mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         ls -la ${{ inputs.output-directory }}/
-        # git add "${{ inputs.output-directory }}/."
-        # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
-        # git push origin HEAD
+        git add "${{ inputs.output-directory }}/."
+        git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
+        git push origin HEAD
       shell: bash
   
-    #- run: curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
-    #  shell: bash
+    - run: curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
         echo "ACTION_REPO=$( echo $GITHUB_ACTION | sed 's/_/\//g' | sed 's/\///' )" >> $GITHUB_ENV
         echo "PR_BRANCH=${{ inputs.pr-branch-prefix }}---$(date +'%Y-%m-%d--%H-%M-%S')" >> $GITHUB_ENV
         echo "PR_MESSAGE=${{ inputs.pr-message }}" >> $GITHUB_ENV
-        echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
+        # echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
         echo "PR_TITLE_APPENDIX= ${{ inputs.target-repo }}" >> $GITHUB_ENV
         echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-repo }}" >> $GITHUB_ENV
         echo "target repo processed as: ${{ inputs.target-repo}}"
@@ -72,30 +72,23 @@ runs:
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       with:
         persist-credentials: false
-        path: "${{ env.TMP_DSTDIR }}"
+        # TODO: is this temp dir actually needed?
+        # path: "${{ env.TMP_DSTDIR }}"
         repository: "${{ inputs.output-repo }}"
-
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: |
-       git config --global user.name "${{ inputs.git-name }}"
-       git config --global user.email "${{ inputs.git-email }}"
-       git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
-       mkdir -p "${{ inputs.output-directory }}"
-      shell: bash
     
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: |
-        git checkout -b "${{ env.PR_BRANCH }}"
+    # - working-directory: "${{ env.TMP_DSTDIR }}"
+    - run: |
+        git config --global user.name "${{ inputs.git-name }}"
+        git config --global user.email "${{ inputs.git-email }}"
+        git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
+        mkdir -p "${{ inputs.output-directory }}"
+        # TODO: See if this still works after swapping checkout step
+        # git checkout -b "${{ env.PR_BRANCH }}"
         git remote add -f ${{ inputs.output-directory }}/${{ inputs.target-repo }} https://github.com/${{ inputs.target-repo }}
         git merge -s ours --no-commit --allow-unrelated-histories ${{ inputs.output-directory }}/${{ inputs.target-repo}}/${{ inputs.output-branch }}
         git read-tree --prefix=${{ inputs.output-directory }}/${{ inputs.target-repo}} -u ${{ inputs.output-directory }}/${{ inputs.target-repo}}/${{ inputs.output-branch }}
         git commit -m "Subtree merged in ${{ inputs.target-repo }}"
+        git checkout -b "${{ env.PR_BRANCH }}"
         git push origin "${{ env.PR_BRANCH }}"
-      shell: bash
-  
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: |
-        prUrl=$(curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }" | jq '.html_url')
-        echo "prUrl=$prUrl" >> "$GITHUB_OUTPUT"
-        # curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
+        curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,43 +1,61 @@
-name: 'Copy to Another Repository'
-description: 'Copy selected file to another repository and create Pull Request (PR).'
-author: 'Sator Imaging'
+name: "Copy to Another Repository"
+description: "Copy selected files to another repository and create Pull Request (PR)."
+author: "Sator Imaging"
 branding:
   icon: copy
   color: purple
 
-
 inputs:
-  target-filepath:
+  target-repo:
+    required: false
+    description: "Name of remote repository to copy file(s) from."
+    default: "cisco-ospo/sample-project"
+  target-path:
     required: true
-    description: 'File path to copy.'
+    description: "File/folder path(s) to copy to the output repository."
+    default: "./*"
   output-repo:
     required: true
-    description: 'Owner/AnotherRepository'
+    description: "Name of the org/repo where the pull request will be filed."
+    default: "cisco-ospo/outbound-review"
   output-branch:
     required: true
-    description: 'Branch name on output repository to create pull request.'
+    description: "Base branch name to file the pull request against."
+    default: "main"
   commit-message-prefix:
-    default: '[actions] '
+    required: false
+    description: "Prefix for the git commit message."
+    default: "[actions] "
   output-directory:
+    required: false
+    description: "Output directory to copy the file(s) to."
     default: "${{ github.event.repository.name }}"
   pr-branch-prefix:
+    required: false
+    description: "Prefix for the pull request branch name."
     default: "actions/${{ github.event.repository.name }}"
   pr-title:
-    default: "GitHub Actions: ${{ github.event.repository.name }}"
+    required: false
+    description: "Title for the GitHub pull request."
+    default: "🤖 GitHub Actions: ${{ github.event.repository.name }}"
   pr-message:
+    required: false
+    description: "Description for the GitHub pull request."
     default: "${{ github.workflow }} on ${{ github.server_url }}/${{ github.repository }}"
   git-name:
+    required: false
+    description: "Name of the committer/bot filing the pull request."
     default: "github-actions[bot]"
   git-email:
-    description: 'Use your "@users.noreply.github.com" address if you want your icon shown in commit messages.'
-    default: 'github-actions[bot]@users.noreply.github.com'
+    required: false
+    description: "Use your `@users.noreply.github.com` address if you want your icon shown in commit messages."
+    default: "github-actions[bot]@users.noreply.github.com"
   git-token:
     required: true
-    description: 'Personal Access Token used to commit/create PR on output repository.'
-
+    description: "Personal Access Token used to commit/create PR on output repository."
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - run: echo '::echo::on'
       shell: bash
@@ -56,22 +74,22 @@ runs:
       shell: bash
     - run: echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
       shell: bash
-    - run: echo "PR_TITLE_APPENDIX= - ${{ inputs.target-filepath }}" >> $GITHUB_ENV
+    - run: echo "PR_TITLE_APPENDIX= - ${{ inputs.target-path }}" >> $GITHUB_ENV
       shell: bash
-    - run: echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-filepath }}" >> $GITHUB_ENV
+    - run: echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-path }}" >> $GITHUB_ENV
       shell: bash
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       with:
         persist-credentials: false
         path: "${{ env.TMP_SRCDIR }}"
+        repository: "${{ inputs.target-repo }}"
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       with:
         persist-credentials: false
         path: "${{ env.TMP_DSTDIR }}"
         repository: "${{ inputs.output-repo }}"
-
 
     - run: git config --global user.name "${{ inputs.git-name }}"
       shell: bash
@@ -95,7 +113,7 @@ runs:
       shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-filepath }}" "${{ inputs.output-directory }}"
+      run: mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "${{ inputs.output-directory }}"
       shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"

--- a/action.yml
+++ b/action.yml
@@ -105,8 +105,8 @@ runs:
       run: |
         # git checkout -b "${{ env.PR_BRANCH }}"
         shopt -s dotglob
-        mv -vf "../${{ env.TMP_SRCDIR }}/*" "${{ inputs.output-directory }}/"
-        ls -la "${{ inputs.output-directory }}/"
+        mv -vf ../${{ env.TMP_SRCDIR }}/* ${{ inputs.output-directory }}/
+        ls -la ${{ inputs.output-directory }}/
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         # git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -98,13 +98,13 @@ runs:
         git config --global user.name "${{ inputs.git-name }}"
         git config --global user.email "${{ inputs.git-email }}"
         git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
-        git checkout -b "${{ env.PR_BRANCH }}"
+        # git checkout -b "${{ env.PR_BRANCH }}"
         # shopt -s dotglob
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         # ls -la ${{ inputs.output-directory }}/*
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         git subtree add --prefix ${{ inputs.output-directory }} https://github.com/${{ inputs.target-repo }} ${{ inputs.output-branch }} --squash
-        git subtree push --prefix=${{ inputs.output-directory }} ${{ inputs.output-branch }} ${{ env.PR_BRANCH }}
+        git subtree push --prefix=${{ inputs.output-directory }} ${{ inputs.output-branch }} ${{ inputs.output-branch }} 
         # git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"

--- a/action.yml
+++ b/action.yml
@@ -93,7 +93,8 @@ runs:
         path: "${{ env.TMP_DSTDIR }}"
         repository: "${{ inputs.output-repo }}"
 
-    - run: | 
+    - working-directory: "${{ env.TMP_DSTDIR }}"
+      run: |
        git config --global user.name "${{ inputs.git-name }}"
        git config --global user.email "${{ inputs.git-email }}"
        git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
@@ -103,19 +104,9 @@ runs:
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |
         # git checkout -b "${{ env.PR_BRANCH }}"
-        echo "working directory: $(pwd)"
-        echo "ls ../"
-        ls -l ../
-        echo "ls ../source/"
-        ls -l ../source/
-        echo "ls ../source/*"
-        ls -l ../source/*
-        echo "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}"
-        echo "../${{ inputs.output-directory }}/"
-        # ls -l  "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}"
-        mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}/"
-        # mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/
-        ls -l "../${{ inputs.output-directory }}/"
+        shopt -s dotglob
+        mv -vf "../${{ env.TMP_SRCDIR }}/*" "${{ inputs.output-directory }}/"
+        ls -la "${{ inputs.output-directory }}/"
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         # git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -99,12 +99,12 @@ runs:
       shell: bash
 
       # we cannot change current directory
-    - run: |
-        cd "${{ env.TMP_DSTDIR }}"
-        pwd
-        ls -l ./*
-        ls -l ../${{ env.TMP_SRCDIR }}/*
-      shell: bash
+    #- run: |
+      #  cd "${{ env.TMP_DSTDIR }}"
+      #  pwd
+      #  ls -l ./*
+      #  ls -l ../${{ env.TMP_SRCDIR }}/*
+      #shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |

--- a/action.yml
+++ b/action.yml
@@ -104,8 +104,8 @@ runs:
         git checkout -b "${{ env.PR_BRANCH }}"
         pwd
         ls -l /home/runner/work/outbound-review/outbound-review/source/*
-        ls -l /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}
         mv -f /home/runner/work/outbound-review/outbound-review/source/README.md /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/
+        ls -l /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         # git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -97,12 +97,13 @@ runs:
       run: |
         git checkout -b "${{ env.PR_BRANCH }}"
         shopt -s dotglob
-        mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} .
+        shopt -s extglob
+        mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}!(.git,.github) ${{ inputs.output-directory }}/
         ls -la ./*
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         # ls -la ${{ inputs.output-directory }}/
         # git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
-        git add --all
+        git add "${{ inputs.output-directory }}/."
         # git add --all "${{ inputs.output-directory }}/."
         git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,10 @@ runs:
       shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "${{ inputs.output-directory }}"
+      run: |
+        pwd
+        ls -l ./*
+        mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "${{ inputs.output-directory }}"
       shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   target-path:
     required: true
     description: "File/folder path(s) to copy to the output repository."
-    default: "*"
+    default: ""
   output-repo:
     required: true
     description: "Name of the org/repo where the pull request will be filed."
@@ -101,7 +101,6 @@ runs:
       shell: bash
     
     - working-directory: "${{ env.TMP_DSTDIR }}"
-      # mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
       run: |
         # git checkout -b "${{ env.PR_BRANCH }}"
         echo "working directory: $(pwd)"
@@ -114,9 +113,9 @@ runs:
         echo "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}"
         echo "../${{ inputs.output-directory }}/"
         # ls -l  "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}"
-        # mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}/"
+        mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}/"
         # mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/
-        # ls -l "../${{ inputs.output-directory }}/"
+        ls -l "../${{ inputs.output-directory }}/"
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         # git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -95,21 +95,18 @@ runs:
        git config --global user.name "${{ inputs.git-name }}"
        git config --global user.email "${{ inputs.git-email }}"
        git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
+       mkdir -p "${{ inputs.output-directory }}"
       shell: bash
-
+    
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |
         # git checkout -b "${{ env.PR_BRANCH }}"
-        mkdir -p "${{ inputs.output-directory }}"
-        pwd
-        ls -l ./*
-        ls -l /home/runner/work/outbound-review/outbound-review/*
-        mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/
+        mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}
         # mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         # git push origin HEAD
       shell: bash
   
-    - run: curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
-      shell: bash
+    #- run: curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
+    #  shell: bash

--- a/action.yml
+++ b/action.yml
@@ -98,20 +98,19 @@ runs:
         git checkout -b "${{ env.PR_BRANCH }}"
         shopt -s dotglob
         shopt -s extglob
-        mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}!(.git,.github) ${{ inputs.output-directory }}/
-        ls -la ./*
+        mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} !(.git) ${{ inputs.output-directory }}/
+        ls -la ${{ inputs.output-directory }}/*
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         # ls -la ${{ inputs.output-directory }}/
         # git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
-        git add "${{ inputs.output-directory }}/."
-        # git add --all "${{ inputs.output-directory }}/."
-        git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
-        git push origin HEAD
+        # git add "${{ inputs.output-directory }}/."
+        # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
+        # git push origin HEAD
       shell: bash
   
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: |
-        curl -X POST -H "Accept:application/vnd.github.v3+json" \
-          "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" \
-          -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
-      shell: bash
+    # - working-directory: "${{ env.TMP_DSTDIR }}"
+    #   run: |
+    #     curl -X POST -H "Accept:application/vnd.github.v3+json" \
+    #       "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" \
+    #       -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
+    #   shell: bash

--- a/action.yml
+++ b/action.yml
@@ -104,8 +104,8 @@ runs:
         git checkout -b "${{ env.PR_BRANCH }}"
         pwd
         ls -l /home/runner/work/outbound-review/outbound-review/source/*
-        mv -f /home/runner/work/outbound-review/outbound-review/source/README.md /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/
-        ls -l /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}
+        mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/
+        ls -l /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/*
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         # git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -85,16 +85,19 @@ runs:
         path: "${{ env.TMP_DSTDIR }}"
         repository: "${{ inputs.output-repo }}"
 
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: |
-       git config --global user.name "${{ inputs.git-name }}"
-       git config --global user.email "${{ inputs.git-email }}"
-       git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
-       mkdir -p "${{ inputs.output-directory }}"
-      shell: bash
+    # - working-directory: "${{ env.TMP_DSTDIR }}"
+    #   run: |
+    #    git config --global user.name "${{ inputs.git-name }}"
+    #    git config --global user.email "${{ inputs.git-email }}"
+    #    git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
+    #    mkdir -p "${{ inputs.output-directory }}"
+    #   shell: bash
     
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |
+        git config --global user.name "${{ inputs.git-name }}"
+        git config --global user.email "${{ inputs.git-email }}"
+        git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
         git checkout -b "${{ env.PR_BRANCH }}"
         # shopt -s dotglob
         # mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
   
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |
-        curl -X POST -H "Accept:application/vnd.github.v3+json" \
-          "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" \
-          -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
+        prUrl=$(curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }" | jq '.html_url')
+        echo "prUrl=$prUrl" >> "$GITHUB_OUTPUT"
+        # curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -102,9 +102,10 @@ runs:
       # mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
       run: |
         git checkout -b "${{ env.PR_BRANCH }}"
+        pwd
         ls -l /home/runner/work/outbound-review/outbound-review/source/*
         ls -l /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}
-        mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}
+        mv -f /home/runner/work/outbound-review/outbound-review/source/README.md /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         # git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -91,45 +91,21 @@ runs:
         path: "${{ env.TMP_DSTDIR }}"
         repository: "${{ inputs.output-repo }}"
 
-    - run: git config --global user.name "${{ inputs.git-name }}"
-      shell: bash
-    - run: git config --global user.email "${{ inputs.git-email }}"
-      shell: bash
-    - run: git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
-      shell: bash
-
-      # we cannot change current directory
-    - run: cd "${{ env.TMP_DSTDIR }}"
-      shell: bash
-
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: git checkout -b "${{ env.PR_BRANCH }}"
-      shell: bash
-
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: mkdir -p "${{ inputs.output-directory }}"
+    - run: | 
+       git config --global user.name "${{ inputs.git-name }}"
+       git config --global user.email "${{ inputs.git-email }}"
+       git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
       shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |
-        pwd
-        ls -l ./*
-        ls -l ../${{ env.TMP_SRCDIR }}/*
-        mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "${{ inputs.output-directory }}"
+        git checkout -b "${{ env.PR_BRANCH }}"
+        mkdir -p "${{ inputs.output-directory }}"
+        mv -vf ".././${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
+        git add "${{ inputs.output-directory }}/."
+        git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
+        git push origin HEAD
       shell: bash
-
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: git add "${{ inputs.output-directory }}/."
-      shell: bash
-
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
-      shell: bash
-
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: git push origin HEAD
-      shell: bash
-
-    # do NOT insert space after colon. colon-space will cause syntax error.
+  
     - run: curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -99,30 +99,22 @@ runs:
       shell: bash
 
       # we cannot change current directory
-    #- run: |
-      #  cd "${{ env.TMP_DSTDIR }}"
-      #  pwd
-      #  ls -l ./*
-      #  ls -l ../${{ env.TMP_SRCDIR }}/*
-      #shell: bash
-
-    - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: |
-        pwd
-        git checkout -b "${{ env.PR_BRANCH }}"
+    - run: cd "${{ env.TMP_DSTDIR }}"
       shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"
-      run: |
-        pwd
-        mkdir -p "${{ inputs.output-directory }}"
-        ls -l ./*
+      run: git checkout -b "${{ env.PR_BRANCH }}"
+      shell: bash
+
+    - working-directory: "${{ env.TMP_DSTDIR }}"
+      run: mkdir -p "${{ inputs.output-directory }}"
       shell: bash
 
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |
         pwd
         ls -l ./*
+        ls -l ../${{ env.TMP_SRCDIR }}/*
         mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "${{ inputs.output-directory }}"
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,7 @@ runs:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       with:
         repository: "${{ inputs.output-repo }}"
+        persist-credentials: false
     
     - run: |
         git config --global user.name "${{ inputs.git-name }}"

--- a/action.yml
+++ b/action.yml
@@ -60,28 +60,24 @@ runs:
       shell: bash
 
     - run: |
-        echo "ACTION_REPO=$( echo $GITHUB_ACTION | sed 's/_/\//g' | sed 's/\///' )" >> $GITHUB_ENV
         echo "PR_BRANCH=${{ inputs.pr-branch-prefix }}---$(date +'%Y-%m-%d--%H-%M-%S')" >> $GITHUB_ENV
         echo "PR_MESSAGE=${{ inputs.pr-message }}" >> $GITHUB_ENV
         echo "PR_TITLE_APPENDIX= ${{ inputs.target-repo }}" >> $GITHUB_ENV
-        echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-repo }}" >> $GITHUB_ENV
-        echo "target repo processed as: ${{ inputs.target-repo}}"
       shell: bash
 
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       with:
         repository: "${{ inputs.output-repo }}"
-        persist-credentials: false
     
     - run: |
         git config --global user.name "${{ inputs.git-name }}"
         git config --global user.email "${{ inputs.git-email }}"
         git config --global url."https://${{ inputs.git-token }}@github.com/".insteadOf "https://github.com/"
         mkdir -p "${{ inputs.output-directory }}"
-        git remote add -f ${{ inputs.output-directory }}/${{ inputs.target-repo }} https://github.com/${{ inputs.target-repo }}
-        git merge -s ours --no-commit --allow-unrelated-histories ${{ inputs.output-directory }}/${{ inputs.target-repo}}/${{ inputs.output-branch }}
-        git read-tree --prefix=${{ inputs.output-directory }}/${{ inputs.target-repo}} -u ${{ inputs.output-directory }}/${{ inputs.target-repo}}/${{ inputs.output-branch }}
-        git commit -m "Subtree merged in ${{ inputs.target-repo }}"
+        git remote add -f "${{ inputs.output-directory }}/${{ inputs.target-repo }}" "https://github.com/${{ inputs.target-repo }}"
+        git merge -s ours --no-commit --allow-unrelated-histories "${{ inputs.output-directory }}/${{ inputs.target-repo }}/${{ inputs.output-branch }}"
+        git read-tree --prefix="${{ inputs.output-directory }}/${{ inputs.target-repo }}" -u "${{ inputs.output-directory }}/${{ inputs.target-repo }}/${{ inputs.output-branch }}"
+        git commit -m "Subtree merged in ${{ inputs.target-repo }} for review"
         git checkout -b "${{ env.PR_BRANCH }}"
         git push origin "${{ env.PR_BRANCH }}"
         curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"

--- a/action.yml
+++ b/action.yml
@@ -63,10 +63,10 @@ runs:
         echo "ACTION_REPO=$( echo $GITHUB_ACTION | sed 's/_/\//g' | sed 's/\///' )" >> $GITHUB_ENV
         echo "PR_BRANCH=${{ inputs.pr-branch-prefix }}---$(date +'%Y-%m-%d--%H-%M-%S')" >> $GITHUB_ENV
         echo "PR_MESSAGE=${{ inputs.pr-message }}" >> $GITHUB_ENV
-        # echo "TMP_SRCDIR=./source" >> $GITHUB_ENV
         echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
         echo "PR_TITLE_APPENDIX= ${{ inputs.target-repo }}" >> $GITHUB_ENV
         echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-repo }}" >> $GITHUB_ENV
+        echo "target repo processed as: ${{ inputs.target-repo}}"
       shell: bash
 
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/action.yml
+++ b/action.yml
@@ -104,14 +104,19 @@ runs:
       # mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
       run: |
         # git checkout -b "${{ env.PR_BRANCH }}"
-        pwd
+        echo "working directory: $(pwd)"
+        echo "ls ../"
         ls -l ../
+        echo "ls ../source/"
         ls -l ../source/
+        echo "ls ../source/*"
         ls -l ../source/*
+        echo "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}"
+        echo "../${{ inputs.output-directory }}/"
         # ls -l  "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}"
         # mv -f "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}/"
         # mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/${{ inputs.output-directory }}/
-        ls -l "../${{ inputs.output-directory }}/"
+        # ls -l "../${{ inputs.output-directory }}/"
         # git add "${{ inputs.output-directory }}/."
         # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         # git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -70,15 +70,13 @@ runs:
       shell: bash
     - run: echo "PR_MESSAGE=${{ inputs.pr-message }}" >> $GITHUB_ENV
       shell: bash
-    - run: echo "TMP_SRCDIR=source" >> $GITHUB_ENV
-    # - run: echo "TMP_SRCDIR=./source" >> $GITHUB_ENV
+    - run: echo "TMP_SRCDIR=./source" >> $GITHUB_ENV
       shell: bash
-    - run: echo "TMP_DSTDIR=dest" >> $GITHUB_ENV
-    # - run: echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
+    - run: echo "TMP_DSTDIR=./dest" >> $GITHUB_ENV
       shell: bash
-    - run: echo "PR_TITLE_APPENDIX= - ${{ inputs.target-path }}" >> $GITHUB_ENV
+    - run: echo "PR_TITLE_APPENDIX= ${{ inputs.target-repo }}" >> $GITHUB_ENV
       shell: bash
-    - run: echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-path }}" >> $GITHUB_ENV
+    - run: echo "COMMIT_TITLE_APPENDIX= - ${{ inputs.target-repo }}" >> $GITHUB_ENV
       shell: bash
 
     - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
@@ -112,5 +110,9 @@ runs:
         git push origin HEAD
       shell: bash
   
-    - run: curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
+    - working-directory: "${{ env.TMP_DSTDIR }}"
+      run: |
+        curl -X POST -H "Accept:application/vnd.github.v3+json" \
+          "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" \
+          -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,8 @@ runs:
         shopt -s dotglob
         mv -vf ../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }} ${{ inputs.output-directory }}/
         ls -la ${{ inputs.output-directory }}/
-        git add --all
+        git submodule add https://github.com/${{ inputs.target-repo }} outbound-review
+        # git add --all
         # git add --all "${{ inputs.output-directory }}/."
         git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
         git push origin HEAD

--- a/action.yml
+++ b/action.yml
@@ -99,13 +99,16 @@ runs:
 
     - working-directory: "${{ env.TMP_DSTDIR }}"
       run: |
-        git checkout -b "${{ env.PR_BRANCH }}"
+        # git checkout -b "${{ env.PR_BRANCH }}"
         mkdir -p "${{ inputs.output-directory }}"
         pwd
-        mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
-        git add "${{ inputs.output-directory }}/."
-        git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
-        git push origin HEAD
+        ls -l ./*
+        ls -l /home/runner/work/outbound-review/outbound-review/*
+        mv -f /home/runner/work/outbound-review/outbound-review/source/* /home/runner/work/outbound-review/outbound-review/
+        # mv -vf "../${{ env.TMP_SRCDIR }}/${{ inputs.target-path }}" "../${{ inputs.output-directory }}"
+        # git add "${{ inputs.output-directory }}/."
+        # git commit -am "${{ inputs.commit-message-prefix }}${{ github.event.repository.name }}${{ env.COMMIT_TITLE_APPENDIX }}"
+        # git push origin HEAD
       shell: bash
   
     - run: curl -X POST -H "Accept:application/vnd.github.v3+json" "https://${{ inputs.git-token }}@api.github.com/repos/${{ inputs.output-repo }}/pulls" -d "{ \"title\":\"${{ inputs.pr-title }}${{ env.PR_TITLE_APPENDIX }}\", \"body\":\"${{ env.PR_MESSAGE }}\", \"head\":\"${{ env.PR_BRANCH }}\", \"base\":\"${{ inputs.output-branch }}\" }"


### PR DESCRIPTION
The original [Copy-to-Another-Repository](https://github.com/sator-imaging/Copy-to-Another-Repository) action assumes you will only want to copy files/folder(s) from your current repository to another repository. This PR aims to support the ability to checkout a remote repository, then copy its files to either the current repository or some other destination.